### PR TITLE
Runscope dash

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,9 +131,27 @@ The runscope adapter requires you to have an access_token from their OAuth2
 export RUNSCOPE_TOKEN=<1234567890>
 ```
 
-No you can use the `mix gecko.load` task to load events from runscope test result APIs into Geckoboard's "Up/Down" monitoring board :
+For runscope, the following datasets may be initialized: 
+```shell
+mix gecko.load -d <dataset_name> -r runscope.dash # Mimics the dashboard of the Runscope web interface
+```
+
+Then, to load data to the above datasets, you must use the following arguments:
+
+* `test` : The ID of the test that you would like to add/update in the Geckoboard dataset
+* `bucket_id` : The ID of the testing bucket
+
+For example, you may add/update the dataset as below:
+
+```shell
+mix gecko.load -d <dataset_name> -t runscope -a test=<test id> bucket_id=<bucket id>
+```
+
+
+You may also use Geckoboard's legacy Uptime widget to briefly summarize the status of your Runscope tests. To do so, simply specify the 
+widget key, as well as the test ID of the target test:
 
 ```shell
 # updates a monitor widget with your runscope last passed test data
-mix gecko.load -w <widget key> -t runscope
+mix gecko.load -w <widget key> -t runscope -a test=<test id> bucket_id=<bucket id>
 ```

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ mix gecko.load -d <dataset_name> -r runscope.dash # Mimics the dashboard of the 
 
 Then, to load data to the above datasets, you must use the following arguments:
 
-* `test` : The ID of the test that you would like to add/update in the Geckoboard dataset
+* `test_id` : The ID of the test that you would like to add/update in the Geckoboard dataset
 * `bucket_id` : The ID of the testing bucket
 
 For example, you may add/update the dataset as below:

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Then, to load data to the above datasets, you must use the following arguments:
 For example, you may add/update the dataset as below:
 
 ```shell
-mix gecko.load -d <dataset_name> -t runscope -a test=<test id> bucket_id=<bucket id>
+mix gecko.load -d <dataset_name> -t runscope -a test=<test id>bucket_id=<bucket id>
 ```
 
 

--- a/datasets/README.md
+++ b/datasets/README.md
@@ -25,3 +25,7 @@ The heroku postgres backup dataset, so we can capture the postgres database back
 ### papertrail.reqs.json
 
 The Requests dataset, so we can capture the request path, the number (1), the request speed and the timestamp.  This will allow us to display basic graphs like API Count, API Avg response times, and totals.
+
+### runscope.dash.json
+
+This schema attempts to mimic the dashboard of the Runscope web interface, showing the name of a given test, the result of the last run, the time of the last run, the success ratio of tests over the past 20 tests, and the average response time of the last test

--- a/datasets/runscope.dash.json
+++ b/datasets/runscope.dash.json
@@ -1,0 +1,30 @@
+{
+	"fields": {
+		"test_id": {
+			"type": "string",
+			"name": "ID of Test"
+		},
+		"name" : {
+			"type": "string",
+			"name": "Test Name"
+		},
+		"last_status": {
+			"type": "string",
+			"name": "Last Status"
+		},
+		"last_test_date": { 
+			"type": "datetime",
+			"name": "Last Tested"
+		},
+		"success_ratio": {
+			"type": "percentage",
+			"name": "Success of Test Over Past 24 hours"
+		},
+		"avg_response_time": {
+			"type": "number",
+			"name": "Average Response Time"
+		}
+	},
+
+	"unique_by": ["test_id", "last_test_date"]
+}

--- a/datasets/runscope.dash.json
+++ b/datasets/runscope.dash.json
@@ -23,6 +23,10 @@
 		"avg_response_time": {
 			"type": "number",
 			"name": "Average Response Time"
+		},
+		"assertion_success_ratio": {
+			"type": "percentage",
+			"name": "Percentage of Assertions Passed"
 		}
 	},
 

--- a/lib/ex_gecko/adapters/runscope.ex
+++ b/lib/ex_gecko/adapters/runscope.ex
@@ -14,7 +14,6 @@ defmodule ExGecko.Adapter.Runscope do
 
   """
   require HTTPoison
-  require IEx
   alias ExGecko.Parser
 
   def url, do: "https://api.runscope.com"
@@ -57,8 +56,7 @@ defmodule ExGecko.Adapter.Runscope do
 
   def get_test_name(opts) do
     case test_detail(opts) do
-      {:ok, %{"data" => detail}} -> IEx.pry
-                                    detail["name"]
+      {:ok, %{"data" => detail}} -> detail["name"]
       _ -> nil
     end
   end
@@ -117,19 +115,19 @@ defmodule ExGecko.Adapter.Runscope do
     |> Float.floor
     |> Kernel.+(62167219200)  # convert unix time to gregorian (since year 0)
     |> Kernel.trunc
-    |> :calendar.gregorian_seconds_to_datetime 
+    |> :calendar.gregorian_seconds_to_datetime
     |> Timex.datetime
     |> Timex.format("{ISOz}")
   end
 
-  def calc_success_ratio(opts) do 
-    timestamp = Timex.Convertable.to_unix(Timex.DateTime.now) - 7 * 24 * 60 * 60    # Timestamp for 24 hours ago
+  def calc_success_ratio(opts) do
+    timestamp = Timex.Convertable.to_unix(Timex.DateTime.now) - 7 * 24 * 60 * 60  # Timestamp for 24 hours ago
     new_opts = if is_nil(opts), do: %{"since" => timestamp, "count" => 50}, else: Map.merge(%{"since" => timestamp, "count" => 50}, opts)
     case test_results(new_opts) do
       {:ok, %{"data" => results}} -> Enum.reduce(results, 0, fn(result, accum) -> if result["result"] == "pass", do: accum + 1, else: accum end) / Enum.count(results)
       _ -> {:error, ""}
     end
-  end 
+  end
 
   def uptime(opts) do
     case last_result(opts) do

--- a/lib/mix/tasks/gecko.load.ex
+++ b/lib/mix/tasks/gecko.load.ex
@@ -1,7 +1,6 @@
 defmodule Mix.Tasks.Gecko.Load do
   use Mix.Task
   require Logger
-  require IEx
   @shortdoc "Populates Geckoboard datasets"
 
   @moduledoc """
@@ -30,7 +29,7 @@ defmodule Mix.Tasks.Gecko.Load do
 
   @doc false
   def run(args) do
-    IEx.pry
+
     {opts, _, _} = OptionParser.parse(args,
       switches: [dataset: :string, type: :string, reset: :string, widget: :string, args: :string],
       aliases: [d: :dataset, t: :type, r: :reset, a: :args, w: :widget]
@@ -52,13 +51,6 @@ defmodule Mix.Tasks.Gecko.Load do
     end
   end
 
-    # REMOVE
-    #
-    #case opts[:reset] do
-    #  nil -> _run(opts[:widget] || opts[:dataset], opts[:type], opts[:args])
-    #  _ -> reset_dataset(opts[:reset], opts[:dataset])
-    #end
-
   def log(msg), do: IO.puts msg
 
   def _run(dataset, _type, _args) when is_nil(dataset), do: log("No 'dataset' or 'widget' was provided, please use the --dataset/-d or --widget/-w switch statement'")
@@ -73,10 +65,8 @@ defmodule Mix.Tasks.Gecko.Load do
   end
 
   def _run(dataset, "runscope", args) do
-    IEx.pry
     case ExGecko.Adapter.Runscope.load_events(args) do
       {:ok, event} -> 
-        IEx.pry
         update_data(dataset, [event])
       _ -> log("Unable to update dataset")
     end

--- a/lib/mix/tasks/gecko.load.ex
+++ b/lib/mix/tasks/gecko.load.ex
@@ -36,13 +36,12 @@ defmodule Mix.Tasks.Gecko.Load do
       )
     Application.ensure_all_started(:httpoison)
     Application.ensure_all_started(:tzdata)
-    
 
     # Identify whether we are updating a dataset or directly updating a widget
     # Providing a widget key to update a widget is a legacy system for Geckoboard
     # Otherwise, provide a dataset name
     case opts[:widget] do
-      nil ->                            #if no widget flag, we're using datasets
+      nil ->                            # if no widget flag, we're using datasets
         case opts[:reset] do
           nil -> _run(opts[:dataset], opts[:type], opts[:args])
           _ -> reset_dataset(opts[:reset], opts[:dataset])
@@ -66,8 +65,7 @@ defmodule Mix.Tasks.Gecko.Load do
 
   def _run(dataset, "runscope", args) do
     case ExGecko.Adapter.Runscope.load_events(args) do
-      {:ok, event} -> 
-        update_data(dataset, [event])
+      {:ok, event} -> update_data(dataset, [event])
       _ -> log("Unable to update dataset")
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,7 @@ defmodule ExGecko.Mixfile do
   #
   # Type "mix help compile.app" for more information
   def application do
-    [applications: [:logger, :httpoison, :porcelain]]
+    [applications: [:logger, :httpoison, :porcelain, :tzdata]]
   end
 
   # Dependencies can be Hex packages:
@@ -43,7 +43,9 @@ defmodule ExGecko.Mixfile do
       {:earmark, "~> 0.1", only: :dev},
       {:ex_doc, "~> 0.11", only: :dev},
       {:dogma, "~> 0.1", only: [:dev, :test]},
-      {:mock, "~> 0.1.1", only: :test}
+      {:mock, "~> 0.1.1", only: :test},
+      {:timex, "~> 2.1.4"},
+      {:tzdata, "~> 0.5.8"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,10 +1,12 @@
-%{"certifi": {:hex, :certifi, "0.4.0", "a7966efb868b179023618d29a407548f70c52466bf1849b9e8ebd0e34b7ea11f", [:rebar3], []},
+%{"certifi": {:hex, :certifi, "0.7.0", "861a57f3808f7eb0c2d1802afeaae0fa5de813b0df0979153cbafcd853ababaf", [:rebar3], []},
+  "combine": {:hex, :combine, "0.9.2", "cd3c8721f378ebe032487d8a4fa2ced3181a456a3c21b16464da8c46904bb552", [:mix], []},
   "dogma": {:hex, :dogma, "0.1.7", "927f76a89a809db96e0983b922fc899f601352690aefa123529b8aa0c45123b2", [:mix], [{:poison, ">= 1.0.0", [hex: :poison, optional: false]}]},
   "earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.12.0", "b774aabfede4af31c0301aece12371cbd25995a21bb3d71d66f5c2fe074c603f", [:mix], [{:earmark, "~> 0.2", [hex: :earmark, optional: false]}]},
   "excoveralls": {:hex, :excoveralls, "0.5.5", "d97b6fc7aa59c5f04f2fa7ec40fc0b7555ceea2a5f7e7c442aad98ddd7f79002", [:mix], [{:exjsx, "~> 3.0", [hex: :exjsx, optional: false]}, {:hackney, ">= 0.12.0", [hex: :hackney, optional: false]}]},
   "exjsx": {:hex, :exjsx, "3.2.0", "7136cc739ace295fc74c378f33699e5145bead4fdc1b4799822d0287489136fb", [:mix], [{:jsx, "~> 2.6.2", [hex: :jsx, optional: false]}]},
-  "hackney": {:hex, :hackney, "1.6.1", "ddd22d42db2b50e6a155439c8811b8f6df61a4395de10509714ad2751c6da817", [:rebar3], [{:certifi, "0.4.0", [hex: :certifi, optional: false]}, {:idna, "1.2.0", [hex: :idna, optional: false]}, {:metrics, "1.0.1", [hex: :metrics, optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, optional: false]}, {:ssl_verify_fun, "1.1.0", [hex: :ssl_verify_fun, optional: false]}]},
+  "gettext": {:hex, :gettext, "0.12.1", "c0624f52763469ef7a3674919ae28b8286d88195b90fa1516180f31bbbd26d14", [:mix], []},
+  "hackney": {:hex, :hackney, "1.6.3", "d489d7ca2d4323e307bedc4bfe684323a7bf773ecfd77938f3ee8074e488e140", [:rebar3, :mix], [{:certifi, "0.7.0", [hex: :certifi, optional: false]}, {:idna, "1.2.0", [hex: :idna, optional: false]}, {:metrics, "1.0.1", [hex: :metrics, optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, optional: false]}]},
   "httpoison": {:hex, :httpoison, "0.8.3", "b675a3fdc839a0b8d7a285c6b3747d6d596ae70b6ccb762233a990d7289ccae4", [:mix], [{:hackney, "~> 1.6.0", [hex: :hackney, optional: false]}]},
   "idna": {:hex, :idna, "1.2.0", "ac62ee99da068f43c50dc69acf700e03a62a348360126260e87f2b54eced86b2", [:rebar3], []},
   "jsx": {:hex, :jsx, "2.6.2", "213721e058da0587a4bce3cc8a00ff6684ced229c8f9223245c6ff2c88fbaa5a", [:mix, :rebar], []},
@@ -14,4 +16,6 @@
   "mock": {:hex, :mock, "0.1.3", "657937b03f88fce89b3f7d6becc9f1ec1ac19c71081aeb32117db9bc4d9b3980", [:mix], [{:meck, "~> 0.8.2", [hex: :meck, optional: false]}]},
   "poison": {:hex, :poison, "1.5.2", "560bdfb7449e3ddd23a096929fb9fc2122f709bcc758b2d5d5a5c7d0ea848910", [:mix], []},
   "porcelain": {:hex, :porcelain, "2.0.1", "9c3db2b47d8cf6879c0d9ac79db8657333974a88faff09e856569e00c1b5e119", [:mix], []},
-  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:rebar, :make], []}}
+  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:rebar, :make], []},
+  "timex": {:hex, :timex, "2.1.6", "2c59cd03074bccea47acd668c4dd6aad269879bcc9d6d4dd98fe0ffbaf48fcaa", [:mix], [{:combine, "~> 0.7", [hex: :combine, optional: false]}, {:gettext, "~> 0.10", [hex: :gettext, optional: false]}, {:tzdata, "~> 0.1.8 or ~> 0.5", [hex: :tzdata, optional: false]}]},
+  "tzdata": {:hex, :tzdata, "0.5.9", "575be217b039057a47e133b72838cbe104fb5329b19906ea4e66857001c37edb", [:mix], [{:hackney, "~> 1.0", [hex: :hackney, optional: false]}]}}

--- a/test/lib/ex_gecko/adapters/runscope_test.exs
+++ b/test/lib/ex_gecko/adapters/runscope_test.exs
@@ -1,0 +1,16 @@
+defmodule ExGecko.Adapter.RunscopeTest do
+  use ExUnit.Case
+  import Mock
+  alias ExGecko.Adapter.Runscope
+  doctest ExGecko.Adapter.Runscope
+
+  @unix 1478133443.0
+
+
+
+  test "should convert unix time to ISO 8601 string" do
+  	resp = Runscope.get_datetime(@unix)
+  	assert "2016-11-03T00:37:23Z" == resp
+  end
+
+end


### PR DESCRIPTION
Implemented the Geckoboard Dataset support into the runscope adapter of Ex_Gecko.

- Created runscope.dash.json schema, which can be used to create a dataset that tracks the percentage of assertions passed by a test, the date of a test, and the average response time for requests.
- Updated Readme.md with instructions on creating the dataset and creating/pushing events to the dataset